### PR TITLE
Fix call* gas calculations

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ Terms:
 ### AB-1: CALL
 
 Gas Calculation:
-- `base_gas = mem_expansion_cost`
+- `base_gas = 700 + mem_expansion_cost`
 - **If** `call_value > 0` (sending value with call):
     - `base_gas += 9000`
     - **If** `is_empty(target_addr)` (forcing a new account to be created in the state trie):
@@ -337,7 +337,7 @@ And the final cost of the operation:
 ### AB-2: CALLCODE
 
 Gas Calculation:
-- `base_gas = mem_expansion_cost`
+- `base_gas = 700 + mem_expansion_cost`
 - **If** `call_value > 0` (sending value with call):
     - `base_gas += 9000`
 
@@ -349,7 +349,7 @@ And the final cost of the operation:
 ### AB-3: DELEGATECALL
 
 Gas Calculation:
-- `base_gas = mem_expansion_cost`
+- `base_gas = 700 + mem_expansion_cost`
 
 Calculate the `gas_sent_with_call` [below](#ac-gas-to-send-with-call-operations).
 
@@ -359,7 +359,7 @@ And the final cost of the operation:
 ### AB-4: STATICCALL
 
 Gas Calculation:
-- `base_gas = mem_expansion_cost`
+- `base_gas = 700 + mem_expansion_cost`
 
 Calculate the `gas_sent_with_call` [below](#ac-gas-to-send-with-call-operations).
 


### PR DESCRIPTION
Addresses #1, adds constant portion of gas costs for call* operations.

Annotated section from the [Jello Paper](https://jellopaper.org/evm.html):
```
// Cextra is the cost of executing the call* op, and is added to the gas sent with the call to get the total cost
// Gcall < SCHED > is the constant portion of the gas cost (700 since Tangerine Whistle hardfork)
rule [Cextra]:
     Cextra(SCHED, ISEMPTY, VALUE)
  => Gcall < SCHED > +Int Cnew(SCHED, ISEMPTY, VALUE) +Int Cxfer(SCHED, VALUE)

// Cnew is the cost of adding a new account to the state trie, applied if nonzero value is sent to an empty account
rule [Cnew]:
     Cnew(SCHED, ISEMPTY:Bool, VALUE)
  => #if ISEMPTY andBool (VALUE =/=Int 0 orBool Gzerovaluenewaccountgas << SCHED >>) #then Gnewaccount < SCHED > #else 0 #fi

// Cxfer is the cost of sending value with a call*
rule [Cxfer.none]: Cxfer(_SCHED, 0) => 0
rule [Cxfer.some]: Cxfer( SCHED, N) => Gcallvalue < SCHED > requires N =/=Int 0
```