### PR TITLE
Berlin Hardfork

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ For operations with dynamic gas costs, see [gas.md](gas.md).
 20      | SHA3          |[A2](gas.md#a2-sha3)| `ost, len` => `keccak256(mem[ost:ost+len])` || keccak256
 21-2F   | *invalid*
 30      | ADDRESS       | 2     | `.` => `address(this)`            || address of executing contract
-31      | BALANCE       | 700   | `addr` => `addr.balance`          || balance, in wei
+31      | BALANCE       |[A5](gas.md#a5-balance-extcodesize-extcodehash)| `addr` => `addr.balance`          || balance, in wei
 32      | ORIGIN        | 2     | `.` => `tx.origin`                || address that originated the tx
 33      | CALLER        | 2     | `.` => `msg.sender`               || address of msg sender
 34      | CALLVALUE     | 2     | `.` => `msg.value`                || msg value, in wei
@@ -50,11 +50,11 @@ For operations with dynamic gas costs, see [gas.md](gas.md).
 38      | CODESIZE      | 2     | `.` => `len(this.code)`           || length of executing contract's code, in bytes
 39      | CODECOPY      |[A3](gas.md#a3-copy-operations)| `dstOst, ost, len` => `.` || mem[dstOst:dstOst+len] := this.code[ost:ost+len] | copy executing contract's bytecode
 3A      | GASPRICE      | 2     | `.` => `tx.gasprice`              || gas price of tx, in wei per unit gas
-3B      | EXTCODESIZE   | 700   | `addr` => `len(addr.code)`        || size of code at addr, in bytes
+3B      | EXTCODESIZE   |[A5](gas.md#a5-balance-extcodesize-extcodehash)| `addr` => `len(addr.code)`        || size of code at addr, in bytes
 3C      | EXTCODECOPY   |[A4](gas.md#a4-extcodecopy)|`addr, dstOst, ost, len` => `.` | mem[dstOst:dstOst+len] := addr.code[ost:ost+len] | copy code from `addr`
 3D      |RETURNDATASIZE | 2     | `.` => `size`                     || size of returned data from last external call, in bytes
 3E      |RETURNDATACOPY |[A3](gas.md#a3-copy-operations)| `dstOst, ost, len` => `.` | mem[dstOst:dstOst+len] := returndata[ost:ost+len] | copy returned data from last external call
-3F      | EXTCODEHASH   | 700   | `addr` => `hash`                  || hash = addr.exists ? keccak256(addr.code) : 0
+3F      | EXTCODEHASH   |[A5](gas.md#a5-balance-extcodesize-extcodehash)| `addr` => `hash`                  || hash = addr.exists ? keccak256(addr.code) : 0
 40      | BLOCKHASH     | 20    | `blockNum` => `blockHash(blockNum)` ||
 41      | COINBASE      | 2     | `.` => `block.coinbase`           || address of miner of current block
 42      | TIMESTAMP     | 2     | `.` => `block.timestamp`          || timestamp of current block
@@ -68,7 +68,7 @@ For operations with dynamic gas costs, see [gas.md](gas.md).
 51      | MLOAD         |3[\*](gas.md#a0-1-memory-expansion)| `ost` => `mem[ost:ost+32]` || read word from memory at offset `ost`
 52      | MSTORE        |3[\*](gas.md#a0-1-memory-expansion)| `ost, val` => `.` | mem[ost:ost+32] := val | write a word to memory
 53      | MSTORE8       |3[\*](gas.md#a0-1-memory-expansion)| `ost, val` => `.` | mem[ost] := val && 0xFF | write a single byte to memory
-54      | SLOAD         | 800   | `key` => `storage[key]`           || read word from storage
+54      | SLOAD         |[A6](gas.md#a6-sload)| `key` => `storage[key]`           || read word from storage
 55      | SSTORE        |[A7](gas.md#a7-sstore)   | `key, val` => `.` | storage[key] := val | write word to storage
 56      | JUMP          | 8     | `dst` => `.`                      || `$pc := dst`
 57      | JUMPI         | 10    | `dst, condition` => `.`           || `$pc := condition ? dst : $pc + 1`

--- a/gas.md
+++ b/gas.md
@@ -36,11 +36,11 @@ These access sets keep track of which addresses and storage slots have already b
 
 - `touched_addresses : Set[Address]`
     - a set where every element is an address
-    - initialized to the empty set, `{}`
+    - initialized to include `tx.origin`, `tx.to`\*, and all precompiles
+        - \* For a contract creation transaction, `touched_addresses` is initialized to include the address of the created contract instead of `tx.to`, which is the zero address.
 - `touched_storage_slots : Set[(Address, Bytes32)]`
     - a set where every element is a tuple, `(address, storage_key)`
-    - initialized to include `tx.origin`, `tx.to`\*, and all precompiles
-        - \* For a contract creation transaction, `touched_storage_slots` is initialized to include the address of the created contract instead of `tx.to`, which is the zero address.
+    - initialized to the empty set, `{}`
 
 The access sets above are relevant for the following operations:
 - `ADDRESS_TOUCHING_OPCODES := { EXTCODESIZE, EXTCODECOPY, EXTCODEHASH, BALANCE, CALL, CALLCODE, DELEGATECALL, STATICCALL, SELFDESTRUCT }`

--- a/gas.md
+++ b/gas.md
@@ -61,6 +61,20 @@ Important Notes:
 - If an execution frame reverts, the access sets will return to the state they were in before the frame was entered.
 - Additions to the `touched_addresses` set for `*CALL` and `CREATE*` opcodes are made immediately *before* the new execution frames are entered, so any failure within a call or contract creation will not remove the target address of the failing `*CALL` or `CREATE*` from the `touched_addresses` set.
 
+#### Pre-populating the Access Sets
+
+[EIP-2930](https://eips.ethereum.org/EIPS/eip-2930) introduced an optional access *list* that can be included as part of a transaction.
+This access list allows elements to be added to the `touched_addresses` and `touched_storage_slots` access *sets* before execution of a transaction begins.
+The cost for doing so is `2400` gas for each address added to `touched_addresses` and `1900` gas for each `(address, storage_key)` pair added to `touched_storage_slots`.
+This cost is charged at the same time as [intrinsic gas](#a0-0-intrinsic-gas).
+
+Important Notes:
+- No `(ADDR, storage_key)` pair can be added to `touched_storage_slots` without also adding `ADDR` to `touched_addresses`.
+- The access list may contain duplicates.
+The addition of a duplicate item to one of the access sets is a no-op, but the cost of addition is still charged.
+- Providing an access list with a transaction can yield a modest discount for each unique access, but this is not always the case.
+See [@fvictorio/gas-costs-after-berlin](https://hackmd.io/@fvictorio/gas-costs-after-berlin) for a more complete discussion.
+
 #
 
 ## A1: EXP

--- a/gas.md
+++ b/gas.md
@@ -30,6 +30,37 @@ Useful Notes:
 - Referencing a zero length range does not require memory to be extended to the beginning of the range.
 - The memory cost function is linear up to 724 bytes of memory used, at which point additional memory costs substantially more.
 
+### A0-2: Access Sets
+As of [EIP-2929](https://eips.ethereum.org/EIPS/eip-2929), two transaction-wide access sets are maintained.
+These access sets keep track of which addresses and storage slots have already been touched within the current transaction.
+
+- `touched_addresses : Set[Address]`
+    - a set where every element is an address
+    - initialized to the empty set, `{}`
+- `touched_storage_slots : Set[(Address, Bytes32)]`
+    - a set where every element is a tuple, `(address, storage_key)`
+    - initialized to include `tx.origin`, `tx.to`\*, and all precompiles
+        - \* For a contract creation transaction, `touched_storage_slots` is initialized to include the address of the created contract instead of `tx.to`, which is the zero address.
+
+The access sets above are relevant for the following operations:
+- `ADDRESS_TOUCHING_OPCODES := { EXTCODESIZE, EXTCODECOPY, EXTCODEHASH, BALANCE, CALL, CALLCODE, DELEGATECALL, STATICCALL, SELFDESTRUCT }`
+- `STORAGE_TOUCHING_OPCODES := { SLOAD, SSTORE }`
+
+#### Updating the Access Sets
+
+When an address is the target of one of the `ADDRESS_TOUCHING_OPCODES`, the address is immediately added to the `touched_addresses` set.
+
+- <code>touched addresses = touched_addresses &#x222A; { target_address }</code>
+
+When a storage slot is the target of one of the `STORAGE_TOUCHING_OPCODES`, the `(address, key)` pair is immediately added to the `touched_storage_slots` set.
+
+- <code>touched_storage_slots = touched_storage_slots &#x222A; { (current_address, target_storage_key) }</code>
+
+Important Notes:
+- Adding duplicate elements to these sets is a no-op. Performant implementations will use a map with more complicated addition logic.
+- If an execution frame reverts, the access sets will return to the state they were in before the frame was entered.
+- Additions to the `touched_addresses` set for `*CALL` and `CREATE*` opcodes are made immediately *before* the new execution frames are entered, so any failure within a call or contract creation will not remove the target address of the failing `*CALL` or `CREATE*` from the `touched_addresses` set.
+
 #
 
 ## A1: EXP
@@ -65,12 +96,42 @@ Gas Calculation:
 ## A4: EXTCODECOPY
 
 Terms:
+- `target_addr`: the address to copy code from (`addr` in the stack representation)
+- `access_cost`: The cost of accessing a warm vs. cold account (see [A0-2](#a0-2-access-sets))
+    - `access_cost = 100` **if** `target_addr` **in** `touched_addresses` (warm access)
+    - `access_cost = 2600` **if** `target_addr` **not in** `touched_addresses` (cold access)
 - `data_size`: size of the data to copy in bytes (`len` in the stack representation)
 - `data_size_words = (data_size + 31) // 32`: number of (32-byte) words in the data to copy
 - `mem_expansion_cost`: the cost of any memory expansion required (see [A0-1](#a0-1-memory-expansion))
 
 Gas Calculation:
-- `gas_cost = 700 + 3 * data_size_words + mem_expansion_cost`
+- `gas_cost = access_cost + 3 * data_size_words + mem_expansion_cost`
+
+
+## A5: BALANCE, EXTCODESIZE, EXTCODEHASH
+
+The opcodes `BALANCE`, `EXTCODESIZE`, `EXTCODEHASH` have the same pricing function based on making a single account access.
+See [A0-2](#a0-2-access-sets) for details on EIP-2929 and `touched_addresses`.
+
+Terms:
+- `target_addr`: the address of interest (`addr` in the opcode stack representations)
+
+Gas Calculation:
+- `gas_cost = 100` **if** `target_addr` **in** `touched_addresses` (warm access)
+- `gas_cost = 2600` **if** `target_addr` **not in** `touched_addresses` (cold access)
+
+
+## A6: SLOAD
+
+See [A0-2](#a0-2-access-sets) for details on EIP-2929 and `touched_storage_slots`.
+
+Terms:
+- `context_addr`: the address of the current execution context (i.e. what `ADDRESS` would put on the stack)
+- `target_storage_key`: The 32-byte storage index to load from (`key` in the stack representation)
+
+Gas Calculation:
+- `gas_cost = 100` **if** `(context_addr, target_storage_key)` **in** `touched_storage_slots` (warm access)
+- `gas_cost = 2100` **if** `(context_addr, target_storage_key)` **not in** `touched_storage_slots` (cold access)
 
 
 ## A7: SSTORE
@@ -82,7 +143,12 @@ The cost of an `SSTORE` operation is dependent on the existing value and the val
 1. The current value of the slot vs. the value to store - changing the value of a slot is more costly than not changing it
 2. "Dirty" vs. "clean" slot - changing a slot that has not yet been changed within the current execution context is more costly than changing a slot that has already been changed
 
+The cost is also dependent on whether or not the targeted storage slot has already been accessed within the same transaction.
+See [A0-2](#a0-2-access-sets) for details on EIP-2929 and `touched_storage_slots`.
+
 Terms:
+- `context_addr`: the address of the current execution context (i.e. what `ADDRESS` would put on the stack)
+- `target_storage_key`: The 32-byte storage index to store to (`key` in the stack representation)
 - `orig_val`: the value of the storage slot if the current transaction is reverted
 - `current_val`: the value of the storage slot immediately *before* the `sstore` op in question
 - `new_val`: the value of the storage slot immediately *after* the `sstore` op in question
@@ -92,18 +158,20 @@ Gas Calculation:
 - `gas_refund = 0`
 - **If** `gas_left <= 2300`:
     - `throw OUT_OF_GAS_ERROR` (can not `sstore` with < 2300 gas for backwards compatibility)
+- **If** `(context_addr, target_storage_key)` **not in** `touched_storage_slots` ([cold access](#a0-2-access-sets)):
+    - `gas_cost += 2100`
 - **If** `new_val == current_val` (no-op):
-    - `gas_cost += 800`
+    - `gas_cost += 100`
 - **Else** `new_val != current_val`:
     - **If** `current_val == orig_val` ("clean slot", not yet updated in current execution context):
         - **If** `orig_val == 0` (slot started zero, currently still zero, now being changed to nonzero):
             - `gas_cost += 20000`
         - **Else** `orig_val != 0` (slot started nonzero, currently still same nonzero value, now being changed):
-            - `gas_cost += 5000` and..
+            - `gas_cost += 2900` and..
             - **If** `new_val == 0` (the value to store is 0):
                 - `gas_refund += 15000`
     - **Else** `current_val != orig_val` ("dirty slot", already updated in current execution context):
-        - `gas_cost += 800` and..
+        - `gas_cost += 100` and..
         - **If** `orig_val != 0` (execution context started with a nonzero value in slot):
             - **If** `current_val == 0` (slot started nonzero, currently zero, now being changed to nonzero):
                 - `gas_refund -= 15000`
@@ -111,9 +179,9 @@ Gas Calculation:
                 - `gas_refund += 15000`
         - **If** `new_val == orig_val` (slot is reset to the value it started with):
             - **If** `orig_val == 0` (slot started zero, currently nonzero, now being reset to zero):
-                - `gas_refund += 19200`
+                - `gas_refund += 19900`
             - **Else** `orig_val != 0` (slot started nonzero, currently different nonzero value, now reset to orig. nonzero value):
-                - `gas_refund += 4200`
+                - `gas_refund += 2800`
 
 
 ## A8: LOG\* Operations
@@ -172,13 +240,16 @@ Similar to selfdestruct, `CALL` incurs an additional cost if it forces an accoun
 Common Terms:
 - `call_value`: the value sent with the call (`val` in the stack representation)
 - `target_addr`: the recipient of the call (`addr` in the stack representation)
+- `access_cost`: The cost of accessing a warm vs. cold account (see [A0-2](#a0-2-access-sets))
+    - `access_cost = 100` **if** `target_addr` **in** `touched_addresses` (warm access)
+    - `access_cost = 2600` **if** `target_addr` **not in** `touched_addresses` (cold access)
 - `mem_expansion_cost`: the cost of any memory expansion required (see [A0-1](#a0-1-memory-expansion))
 - `gas_sent_with_call`: the gas ultimately sent with the call
 
 ### AA-1: CALL
 
 Gas Calculation:
-- `base_gas = 700 + mem_expansion_cost`
+- `base_gas = access_cost + mem_expansion_cost`
 - **If** `call_value > 0` (sending value with call):
     - `base_gas += 9000`
     - **If** `is_empty(target_addr)` (forcing a new account to be created in the state trie):
@@ -192,7 +263,7 @@ And the final cost of the operation:
 ### AA-2: CALLCODE
 
 Gas Calculation:
-- `base_gas = 700 + mem_expansion_cost`
+- `base_gas = access_cost + mem_expansion_cost`
 - **If** `call_value > 0` (sending value with call):
     - `base_gas += 9000`
 
@@ -204,7 +275,7 @@ And the final cost of the operation:
 ### AA-3: DELEGATECALL
 
 Gas Calculation:
-- `base_gas = 700 + mem_expansion_cost`
+- `base_gas = access_cost + mem_expansion_cost`
 
 Calculate the `gas_sent_with_call` [below](#aa-f-gas-to-send-with-call-operations).
 
@@ -214,7 +285,7 @@ And the final cost of the operation:
 ### AA-4: STATICCALL
 
 Gas Calculation:
-- `base_gas = 700 + mem_expansion_cost`
+- `base_gas = access_cost + mem_expansion_cost`
 
 Calculate the `gas_sent_with_call` [below](#aa-f-gas-to-send-with-call-operations).
 
@@ -252,6 +323,9 @@ The gas cost of a `SELFDESTRUCT` operation is dependent on whether or not the op
 If a nonzero amount of eth is sent to an address that was previously empty, an additional cost is incurred.
 "Empty", in this case is defined according to [EIP-161](https://eips.ethereum.org/EIPS/eip-161) (`balance == nonce == code == 0x`).
 
+The cost also increases if the operation requires a cold access of the recipient address.
+See [A0-2](#a0-2-access-sets) for details on EIP-2929 and `touched_addresses`.
+
 Terms:
 - `target_addr`: the recipient of the self-destructing contract's funds (`addr` in the stack representation)
 - `context_addr`: the address of the current execution context (i.e. what `ADDRESS` would put on the stack)
@@ -261,6 +335,8 @@ Gas Calculation:
 - `gas_refund = 24000`: base refund, only given for first self-destruct of the same contract within a transaction
 - **If** `balance(context_addr) > 0 && is_empty(target_addr)` (sending funds to a previously empty address):
     - `gas_cost += 25000`
+- **If** `target_addr` **not in** `touched_addresses` (cold access):
+    - `gas_cost += 2600`
 
 
 ## AF: INVALID

--- a/update_log.md
+++ b/update_log.md
@@ -1,3 +1,4 @@
-| Date | Hardfork | Notes |
+| Date | Hardfork | Branch |
 | :---:| :--- | :--- |
-29 Jan 2020 | [Istanbul](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1679.md) | Initial update
+29 Jan 2020   | [Istanbul](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1679.md) | [hardfork-istanbul](https://github.com/wolflo/evm-opcodes/tree/hardfork-istanbul)
+14 April 2021 | [Berlin](https://github.com/ethereum/eth1.0-specs/blob/master/network-upgrades/mainnet-upgrades/berlin.md) | main


### PR DESCRIPTION
Updates for the [Berlin](https://github.com/ethereum/eth1.0-specs/blob/master/network-upgrades/mainnet-upgrades/berlin.md) Hardfork (see #3).

Todo:
- Verify the EIP-2929 changes
- Clarify the behavior of the `touched_addresses` set in the event of reverting calls or creates
- Add mention of EIP-2930 to the Access Sets section
- Update `update_log.md`