### PR TITLE
London Hardfork

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ For operations with dynamic gas costs, see [gas.md](gas.md).
 45      | GASLIMIT      | 2     | `.` => `block.gaslimit`           || gas limit of current block
 46      | CHAINID       | 2     | `.` => `chain_id`                 || push current [chain id](https://eips.ethereum.org/EIPS/eip-155) onto stack
 47      | SELFBALANCE   | 5     | `.` => `address(this).balance`    || balance of executing contract, in wei
-48      | BASEFEE       | 2     | `.` => `block.basefee`            || base fee for this block (>= London fork) 
+48      | BASEFEE       | 2     | `.` => `block.basefee`            || base fee of current block
 49-4F   | *invalid*
 50      | POP           | 2     | `_anon` => `.` || remove item from top of stack and discard it
 51      | MLOAD         |3[\*](gas.md#a0-1-memory-expansion)| `ost` => `mem[ost:ost+32]` || read word from memory at offset `ost`

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ For operations with dynamic gas costs, see [gas.md](gas.md).
 37      | CALLDATACOPY  |[A3](gas.md#a3-copy-operations)| `dstOst, ost, len` => `.` | mem[dstOst:dstOst+len] := msg.data[ost:ost+len | copy msg data
 38      | CODESIZE      | 2     | `.` => `len(this.code)`           || length of executing contract's code, in bytes
 39      | CODECOPY      |[A3](gas.md#a3-copy-operations)| `dstOst, ost, len` => `.` || mem[dstOst:dstOst+len] := this.code[ost:ost+len] | copy executing contract's bytecode
-3A      | GASPRICE      | 2     | `.` => `tx.gasprice`              || gas price of tx, in wei per unit gas
+3A      | GASPRICE      | 2     | `.` => `tx.gasprice`              || gas price of tx, in wei per unit gas [\*\*](https://github.com/ethereum/EIPs/blob/0341984ff14c8ce398f6d2b3e009c07cd99df8eb/EIPS/eip-1559.md#gasprice)
 3B      | EXTCODESIZE   |[A5](gas.md#a5-balance-extcodesize-extcodehash)| `addr` => `len(addr.code)`        || size of code at addr, in bytes
 3C      | EXTCODECOPY   |[A4](gas.md#a4-extcodecopy)|`addr, dstOst, ost, len` => `.` | mem[dstOst:dstOst+len] := addr.code[ost:ost+len] | copy code from `addr`
 3D      |RETURNDATASIZE | 2     | `.` => `size`                     || size of returned data from last external call, in bytes

--- a/gas.md
+++ b/gas.md
@@ -260,6 +260,8 @@ Terms:
 Gas Calculation:
 - `code_deposit_cost = 200 * returned_code_size`
 
+A note related to the code deposit step of contract creation:
+As of [EIP-3541](https://eips.ethereum.org/EIPS/eip-3541), any code returned from a contract creation (i.e. what *would* become the deployed contract code), results in an exceptional abort of the entire contract creation if the code's first byte is `0xEF`.
 
 ## AA: CALL\* Operations
 Gas costs for `CALL`, `CALLCODE`, `DELEGATECALL`, and `STATICCALL` operations.

--- a/gas.md
+++ b/gas.md
@@ -193,7 +193,7 @@ Gas Calculation:
         - **If** `orig_val != 0` (execution context started with a nonzero value in slot):
             - **If** `current_val == 0` (slot started nonzero, currently zero, now being changed to nonzero):
                 - `gas_refund -= 15000`
-            - **If** `new_val == 0` (slot started nonzero, currently still nonzero, now being changed to zero):
+            - **Else if** `new_val == 0` (slot started nonzero, currently still nonzero, now being changed to zero):
                 - `gas_refund += 15000`
         - **If** `new_val == orig_val` (slot is reset to the value it started with):
             - **If** `orig_val == 0` (slot started zero, currently nonzero, now being reset to zero):

--- a/gas.md
+++ b/gas.md
@@ -79,6 +79,21 @@ The addition of a duplicate item to one of the access sets is a no-op, but the c
 - Providing an access list with a transaction can yield a modest discount for each unique access, but this is not always the case.
 See [@fvictorio/gas-costs-after-berlin](https://hackmd.io/@fvictorio/gas-costs-after-berlin) for a more complete discussion.
 
+### A0-3: Gas Refunds
+Originally intended to provide incentive for clearing unused state, the total `gas_refund` is tracked throughout the execution of a transaction.
+As of [EIP-3529](https://eips.ethereum.org/EIPS/eip-3529), `SSTORE` is the only operation that potentially provides a gas refund.
+
+The maximum refund for a transaction is capped at 1/5<sup>th</sup> the *gas consumed* for the entire transaction.
+```
+refund_amt := min(gas_refund, tx.gas_used // 5)
+```
+The *gas consumed* includes the [intrinsic gas](#a0-0-intrinsic-gas), the cost of [pre-populating](#pre-populating-the-access-sets) the access sets, and the cost of any code execution.
+
+When a transaction is finalized, the gas used by the transaction is decreased by `refund_amt`.
+This effectively reimburses <code>refund_amt&#160;\*&#160;tx.gasprice</code> to `tx.origin`, but it has the added effect of decreasing the impact of the transaction on the total gas consumed in the block (for purposes of determining the block gas limit).
+
+Because the gas refund is not applied until the end of a transaction, a nonzero refund will not affect whether or not a transaction results in an `OUT_OF_GAS` exception.
+
 #
 
 ## A1: EXP
@@ -187,14 +202,14 @@ Gas Calculation:
         - **Else** `orig_val != 0` (slot started nonzero, currently still same nonzero value, now being changed):
             - `gas_cost += 2900` and update the refund as follows..
             - **If** `new_val == 0` (the value to store is 0):
-                - `gas_refund += 15000`
+                - `gas_refund += 4800`
     - **Else** `current_val != orig_val` ("dirty slot", already updated in current execution context):
         - `gas_cost += 100` and update the refund as follows..
         - **If** `orig_val != 0` (execution context started with a nonzero value in slot):
             - **If** `current_val == 0` (slot started nonzero, currently zero, now being changed to nonzero):
-                - `gas_refund -= 15000`
+                - `gas_refund -= 4800`
             - **Else if** `new_val == 0` (slot started nonzero, currently still nonzero, now being changed to zero):
-                - `gas_refund += 15000`
+                - `gas_refund += 4800`
         - **If** `new_val == orig_val` (slot is reset to the value it started with):
             - **If** `orig_val == 0` (slot started zero, currently nonzero, now being reset to zero):
                 - `gas_refund += 19900`
@@ -350,7 +365,6 @@ Terms:
 
 Gas Calculation:
 - `gas_cost = 5000`: base cost
-- `gas_refund = 24000`: base refund, only given for first self-destruct of the same contract within a transaction
 - **If** `balance(context_addr) > 0 && is_empty(target_addr)` (sending funds to a previously empty address):
     - `gas_cost += 25000`
 - **If** `target_addr` **not in** `touched_addresses` (cold access):

--- a/update_log.md
+++ b/update_log.md
@@ -1,4 +1,5 @@
 | Date | Hardfork | Branch |
 | :---:| :--- | :--- |
 29 Jan 2020   | [Istanbul](https://github.com/ethereum/eth1.0-specs/blob/29a892ee02f780cd355f164d829ac99a6f144ec4/network-upgrades/mainnet-upgrades/istanbul.md) | [hardfork-istanbul](https://github.com/wolflo/evm-opcodes/tree/hardfork-istanbul)
-14 April 2021 | [Berlin](https://github.com/ethereum/eth1.0-specs/blob/29a892ee02f780cd355f164d829ac99a6f144ec4/network-upgrades/mainnet-upgrades/berlin.md) | main
+14 April 2021 | [Berlin](https://github.com/ethereum/eth1.0-specs/blob/29a892ee02f780cd355f164d829ac99a6f144ec4/network-upgrades/mainnet-upgrades/berlin.md) | [hardfork-berlin](https://github.com/wolflo/evm-opcodes/tree/hardfork-berlin)
+4 August 2021 | [London](https://github.com/ethereum/eth1.0-specs/blob/29a892ee02f780cd355f164d829ac99a6f144ec4/network-upgrades/mainnet-upgrades/london.md) | main

--- a/update_log.md
+++ b/update_log.md
@@ -2,4 +2,4 @@
 | :---:| :--- | :--- |
 29 Jan 2020   | [Istanbul](https://github.com/ethereum/eth1.0-specs/blob/29a892ee02f780cd355f164d829ac99a6f144ec4/network-upgrades/mainnet-upgrades/istanbul.md) | [hardfork-istanbul](https://github.com/wolflo/evm-opcodes/tree/hardfork-istanbul)
 14 April 2021 | [Berlin](https://github.com/ethereum/eth1.0-specs/blob/29a892ee02f780cd355f164d829ac99a6f144ec4/network-upgrades/mainnet-upgrades/berlin.md) | [hardfork-berlin](https://github.com/wolflo/evm-opcodes/tree/hardfork-berlin)
-4 August 2021 | [London](https://github.com/ethereum/eth1.0-specs/blob/29a892ee02f780cd355f164d829ac99a6f144ec4/network-upgrades/mainnet-upgrades/london.md) | main
+5 August 2021 | [London](https://github.com/ethereum/eth1.0-specs/blob/29a892ee02f780cd355f164d829ac99a6f144ec4/network-upgrades/mainnet-upgrades/london.md) | main


### PR DESCRIPTION
Updates for the [London](https://github.com/ethereum/eth1.0-specs/blob/29a892ee02f780cd355f164d829ac99a6f144ec4/network-upgrades/mainnet-upgrades/london.md) Hardfork (see #10).

Planned for block `12965000` (August 4, 2021).