### PR TITLE
Add a section to clarify notation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 # EVM Opcodes
-An updated version of the EVM reference page at [ethervm.io](https://ethervm.io/) (this appears to no longer be available).
-Also drawn from the [Yellow Paper](https://ethereum.github.io/yellowpaper/paper.pdf), the [Jello Paper](https://jellopaper.org/evm/), and the [geth](https://github.com/ethereum/go-ethereum) implementation.
-This is intended to be an accessible reference, but it is not particularly rigorous.
+Opcode costs are drawn from the [Yellow Paper](https://ethereum.github.io/yellowpaper/paper.pdf), the [Jello Paper](https://jellopaper.org/evm/), and the [geth](https://github.com/ethereum/go-ethereum) implementation.
+This is intended to be an accessible reference, but it is informal and does not address opcode semantics.
 If you want to be certain of correctness and aware of every edge case, I would suggest using the Jello Paper or a client implementation.
 
 For operations with dynamic gas costs, see [gas.md](gas.md).
+
+### Notation
+* `a, b` => `a + b` indicates that the `ADD` opcode takes two items off the stack (`a` and `b`) and places the sum of these two elements on the stack. The leftmost item (`a`) is the top of the stack. All stack descriptions elide subsequent items on the stack, but opcodes have no effect on the stack outside of the stack items on which they operate, with the exception of overflowing the stack. The maximum stack size is 1024 items, and all stack items are 32 bytes.
+* `a // b` indicates flooring division. The result of division by 0 in the EVM is 0.
+* All arithmetic operations are modulo 2\*\*256.
+* Including the designated `INVALID` opcode, the EVM currently implements 141 opcodes, 65 of which are duplicates indicating the number of operands (`PUSHn`, `DUPn`, `SWAPn`, `LOGn`).
 
 | Hex   | Name          | Gas   | Stack      | Mem / Storage | Notes |
 | :---: | :---          | :---: | :---       | :---          | :---  |
@@ -148,7 +153,7 @@ A2      | LOG2          |[A8](gas.md#a8-log-operations)| `ost, len, topic0, topi
 A3      | LOG3          |[A8](gas.md#a8-log-operations)| `ost, len, topic0, topic1, topic2` => `.` || LOG1(memory[ost:ost+len], topic0, topic1, topic2)
 A4      | LOG4          |[A8](gas.md#a8-log-operations)| `ost, len, topic0, topic1, topic2, topic3` => `.` || LOG1(memory[ost:ost+len],&#160;topic0,&#160;topic1,&#160;topic2,&#160;topic3)
 A5-EF   | *invalid*
-F0      | CREATE        |[A9](gas.md#a9-create-operations)| `val, ost, len` => `addr` || addr = keccak256(rlp([address(this), this.nonce]))
+F0      | CREATE        |[A9](gas.md#a9-create-operations)| `val, ost, len` => `addr` || addr = keccak256(rlp\_encode([address(this), this.nonce]))
 F1      | CALL          |[AA](gas.md#aa-call-operations)| <code>gas,&#160;addr,&#160;val,&#160;argOst,&#160;argLen,&#160;retOst,&#160;retLen</code> => `success` | mem[retOst:retOst+retLen] := returndata |
 F2      | CALLCODE      |[AA](gas.md#aa-call-operations)| `gas, addr, val, argOst, argLen, retOst, retLen` => `success` | mem[retOst:retOst+retLen]&#160;=&#160;returndata | same&#160;as&#160;DELEGATECALL,&#160;but&#160;does&#160;not&#160;propagate&#160;original&#160;msg.sender&#160;and&#160;msg.value
 F3      | RETURN        |0[\*](gas.md#a0-1-memory-expansion)| `ost, len` => `.` || return mem[ost:ost+len]

--- a/README.md
+++ b/README.md
@@ -6,11 +6,14 @@ If you want to be certain of correctness and aware of every edge case, I would s
 For operations with dynamic gas costs, see [gas.md](gas.md).
 
 ### Notation
-* `a, b` => `a + b` indicates that the `ADD` opcode takes two items off the stack (`a` and `b`) and places the sum of these two elements on the stack. The leftmost item (`a`) is the top of the stack. All stack descriptions elide subsequent items on the stack, but opcodes have no effect on the stack outside of the stack items on which they operate, with the exception of overflowing the stack. The maximum stack size is 1024 items, and all stack items are 32 bytes.
+* `a, b` => `a + b` indicates that the `ADD` opcode takes two items off the stack (`a` and `b`) and places the sum of these two values on the stack. The leftmost item (`a`) is the top of the stack.
+* All stack descriptions elide subsequent items that may be on the stack. It can be assumed that unspecified stack elements do not influence the semantics of an operation, except when a stack overflow would result.
+* The maximum stack size is 1024 items, and all stack items are 32 bytes.
 * `a // b` indicates flooring division. The result of division by 0 in the EVM is 0.
 * All arithmetic operations are modulo 2\*\*256.
 * Including the designated `INVALID` opcode, the EVM currently implements 141 opcodes, 65 of which are duplicates indicating the number of operands (`PUSHn`, `DUPn`, `SWAPn`, `LOGn`).
 
+#
 | Hex   | Name          | Gas   | Stack      | Mem / Storage | Notes |
 | :---: | :---          | :---: | :---       | :---          | :---  |
 |       |               |       | top, bottom|               |       |

--- a/gas.md
+++ b/gas.md
@@ -83,11 +83,11 @@ See [@fvictorio/gas-costs-after-berlin](https://hackmd.io/@fvictorio/gas-costs-a
 Originally intended to provide incentive for clearing unused state, the total `gas_refund` is tracked throughout the execution of a transaction.
 As of [EIP-3529](https://eips.ethereum.org/EIPS/eip-3529), `SSTORE` is the only operation that potentially provides a gas refund.
 
-The maximum refund for a transaction is capped at 1/5<sup>th</sup> the *gas consumed* for the entire transaction.
+The maximum refund for a transaction is capped at 1/5<sup>th</sup> the gas consumed for the entire transaction.
 ```
-refund_amt := min(gas_refund, tx.gas_used // 5)
+refund_amt := min(gas_refund, tx.gas_consumed // 5)
 ```
-The *gas consumed* includes the [intrinsic gas](#a0-0-intrinsic-gas), the cost of [pre-populating](#pre-populating-the-access-sets) the access sets, and the cost of any code execution.
+The gas consumed includes the [intrinsic gas](#a0-0-intrinsic-gas), the cost of [pre-populating](#pre-populating-the-access-sets) the access sets, and the cost of any code execution.
 
 When a transaction is finalized, the gas used by the transaction is decreased by `refund_amt`.
 This effectively reimburses <code>refund_amt&#160;\*&#160;tx.gasprice</code> to `tx.origin`, but it has the added effect of decreasing the impact of the transaction on the total gas consumed in the block (for purposes of determining the block gas limit).

--- a/gas.md
+++ b/gas.md
@@ -23,7 +23,7 @@ Terms:
 
 Gas Calculation:
 - <code>gas\_cost = <em>C<sub>mem</sub>(new_state)</em> - <em>C<sub>mem</sub>(old_state)</em></code>
-- <code>gas\_cost = (new\_mem\_size\_words ^ 2 / 512) + (3 * new\_mem\_size\_words) - <em>C<sub>mem</sub>(old_state)</em></code>
+- <code>gas\_cost = (new\_mem\_size\_words ^ 2 // 512) + (3 * new\_mem\_size\_words) - <em>C<sub>mem</sub>(old_state)</em></code>
 
 Useful Notes:
 - The following opcodes incur a memory expansion cost in addition to their otherwise static gas cost: `RETURN`, `REVERT`, `MLOAD`, `MSTORE`, `MSTORE8`.


### PR DESCRIPTION
Includes some minor clarifications for opcodes and gas costs.