### PR TITLE
Mention updated version at ethereum.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # EVM Opcodes
+
+An updated version of this table is at https://ethereum.org/en/developers/docs/evm/opcodes
+
 Opcode costs are drawn from the [Yellow Paper](https://ethereum.github.io/yellowpaper/paper.pdf), the [Jello Paper](https://jellopaper.org/evm/), and the [geth](https://github.com/ethereum/go-ethereum) implementation.
 This is intended to be an accessible reference, but it is informal and does not address opcode semantics.
 If you want to be certain of correctness and aware of every edge case, I would suggest using the Jello Paper or a client implementation.


### PR DESCRIPTION
ethereum.org updates can be seen here:
https://github.com/ethereum/ethereum-org-website/commits/dev/src/content/developers/docs/evm/opcodes/index.md

An alternative to this PR is to make the same updates in this repo, but it doesn't appear to be a sustainable alternative?